### PR TITLE
Add ReadWriteCloser interface

### DIFF
--- a/datachannel.go
+++ b/datachannel.go
@@ -10,6 +10,28 @@ import (
 
 const receiveMTU = 8192
 
+// Reader is an extended io.Reader
+// that also returns if the message is text.
+type Reader interface {
+	ReadDataChannel([]byte) (int, bool, error)
+}
+
+// Writer is an extended io.Writer
+// that also allows indicating if a message is text.
+type Writer interface {
+	WriteDataChannel([]byte, bool) (int, error)
+}
+
+// ReadWriteCloser is an extended io.ReadWriteCloser
+// that also implements our Reader and Writer.
+type ReadWriteCloser interface {
+	io.Reader
+	io.Writer
+	Reader
+	Writer
+	io.Closer
+}
+
 // DataChannel represents a data channel
 type DataChannel struct {
 	Config

--- a/datachannel_test.go
+++ b/datachannel_test.go
@@ -10,6 +10,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Check we implement our ReadWriteCloser
+var _ ReadWriteCloser = (*DataChannel)(nil)
+
 func createNewAssociationPair(br *test.Bridge) (*sctp.Association, *sctp.Association, error) {
 	var a0, a1 *sctp.Association
 	var err0, err1 error


### PR DESCRIPTION
The goal is to allow other implementations.

This is in preparation of a WASM version of `webrtc.DataChannel.Detach()`.